### PR TITLE
feat: Add automated tag creation with interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following command-line flags are available to customize the behavior of `get
 | `--publish` | Automatically create and push git tags when new versions are detected. This eliminates the need for manual tag creation and pushing |
 
 When `--publish` is not used, the CLI will enter an interactive mode after detecting version changes, asking whether to:
-- Create and publish tags (Y)
+- Create and publish tags (Y) - this is the default
 - Skip tag creation (N)
 - Create tags without publishing (C)
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,13 @@ The following command-line flags are available to customize the behavior of `get
 | `--verbose` | Enable verbose logging mode. Shows detailed information about commit analysis, file changes, and decision-making process            |
 | `--publish` | Automatically create and push git tags when new versions are detected. This eliminates the need for manual tag creation and pushing |
 
+When `--publish` is not used, the CLI will enter an interactive mode after detecting version changes, asking whether to:
+- Create and publish tags (Y)
+- Skip tag creation (N)
+- Create tags without publishing (C)
+
+This interactive mode provides flexibility when you want to review the changes before pushing tags to the remote repository.
+
 More flags will be added in future releases to provide additional functionality and customization options.
 
 ## GitHub Action Usage

--- a/README.md
+++ b/README.md
@@ -116,18 +116,21 @@ The tool automatically detects if it's running in a CI environment (GitHub Actio
 
 The following command-line flags are available to customize the behavior of `get-next-versions`:
 
-| Flag        | Description                                                                                                                         |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `--json`    | Output results in JSON format instead of human-readable CLI output. Good for CI environments.                                       |
-| `--verbose` | Enable verbose logging mode. Shows detailed information about commit analysis, file changes, and decision-making process            |
-| `--publish` | Automatically create and push git tags when new versions are detected. This eliminates the need for manual tag creation and pushing |
+| Flag        | Description                                                                                                                                                                        |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--json`    | Output results in JSON format instead of human-readable CLI output. Good for CI environments.                                                                                      |
+| `--verbose` | Enable verbose logging mode. Shows detailed information about commit analysis, file changes, and decision-making process (does not work in CI or when `--json` is used)            |
+| `--publish` | Automatically create and push git tags when new versions are detected. This eliminates the need for manual tag creation and pushing (does not work in CI or when `--json` is used) |
 
 When `--publish` is not used, the CLI will enter an interactive mode after detecting version changes, asking whether to:
+
 - Create and publish tags (Y) - this is the default
 - Skip tag creation (N)
 - Create tags without publishing (C)
 
 This interactive mode provides flexibility when you want to review the changes before pushing tags to the remote repository.
+
+> Note that when `--json` is used, the interactive mode is disabled and `--publish` is not available.
 
 More flags will be added in future releases to provide additional functionality and customization options.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ git push origin "pkg-v1.1.0" # or git push --tags
 
 The tool automatically detects if it's running in a CI environment (GitHub Actions, Jenkins, etc.) and will output JSON format when appropriate. Check out the [output examples below](#cli-output-formats).
 
+### CLI Flags
+
+The following command-line flags are available to customize the behavior of `get-next-versions`:
+
+| Flag        | Description                                                                                                                         |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--json`    | Output results in JSON format instead of human-readable CLI output. Good for CI environments.                                       |
+| `--verbose` | Enable verbose logging mode. Shows detailed information about commit analysis, file changes, and decision-making process            |
+| `--publish` | Automatically create and push git tags when new versions are detected. This eliminates the need for manual tag creation and pushing |
+
+More flags will be added in future releases to provide additional functionality and customization options.
+
 ## GitHub Action Usage
 
 ```yaml

--- a/src/commits.ts
+++ b/src/commits.ts
@@ -146,6 +146,20 @@ export function getChangedFilesInCommit(commitHash: string): string[] {
 }
 
 /**
+ * Creates a new git tag with the given name.
+ *
+ * @param tag - The name of the tag to create.
+ * @param publish - If true, the tag will be pushed to the origin repository
+ * after creation.
+ */
+export function createTag(tag: string, publish: boolean = true): void {
+  runCommand(`git tag ${tag}`);
+  if (publish) {
+    runCommand(`git push origin ${tag}`);
+  }
+}
+
+/**
  * Runs a command and returns the result as a string.
  *
  * Returns `undefined` if the command fails or produces no output.
@@ -153,7 +167,7 @@ export function getChangedFilesInCommit(commitHash: string): string[] {
  * @param command - The command to run.
  * @returns The output of the command as a string, if successful.
  */
-export function runCommand(command: string): string | undefined {
+function runCommand(command: string): string | undefined {
   try {
     return execSync(command).toString().trim();
   } catch {

--- a/src/commits.ts
+++ b/src/commits.ts
@@ -96,9 +96,10 @@ export function getTagInfos(tag: string):
  * @returns The commit range to analyze, either a specific range or just HEAD.
  */
 export function getCommitRange(prefix: string, limit?: number): string {
+  const limitUse = limit && limit > 0 && limit < 1_000 ? limit : undefined;
   const lastTag = getLastTag(prefix);
   const until = lastTag ? `${lastTag}..HEAD` : "HEAD";
-  return until + (limit ? `~${limit}` : "");
+  return until + (limitUse ? `~${limitUse}` : "");
 }
 
 /**

--- a/src/commits.ts
+++ b/src/commits.ts
@@ -146,6 +146,22 @@ export function getChangedFilesInCommit(commitHash: string): string[] {
 }
 
 /**
+ * Runs a command and returns the result as a string.
+ *
+ * Returns `undefined` if the command fails or produces no output.
+ *
+ * @param command - The command to run.
+ * @returns The output of the command as a string, if successful.
+ */
+export function runCommand(command: string): string | undefined {
+  try {
+    return execSync(command).toString().trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Retrieves a list of commits within a given range.
  *
  * The commits are fetched using `git log`, and the commit range is passed
@@ -170,21 +186,5 @@ function getCommits(commitRange: string): string[] {
     return commitsRaw.toString().trim().split("\n").filter(Boolean);
   } catch {
     return [];
-  }
-}
-
-/**
- * Runs a command and returns the result as a string.
- *
- * Returns `undefined` if the command fails or produces no output.
- *
- * @param command - The command to run.
- * @returns The output of the command as a string, if successful.
- */
-function runCommand(command: string): string | undefined {
-  try {
-    return execSync(command).toString().trim();
-  } catch {
-    return undefined;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,13 +186,10 @@ export function checkVersions(isCI: boolean = false): void {
                   normalizedFile === normalizedDir;
           })
         ) {
-          addToList(`Direct changes in ${pkg.directory}`);
+          const message = `Direct changes in ${pkg.directory}`;
+          addToList(message);
           if (!jsonOutput && verboseMode) {
-            console.log(
-              colors.dim +
-                "  → Direct changes in package directory" +
-                colors.reset,
-            );
+            console.log(colors.dim + `  → ${message}` + colors.reset);
           }
         }
 
@@ -208,13 +205,10 @@ export function checkVersions(isCI: boolean = false): void {
               );
             });
             if (matchingChanges.length > 0) {
-              addToList(`Affected by changes in dependent package ${dep}`);
+              const message = `Affected by changes in dependent package ${dep}`;
+              addToList(message);
               if (!jsonOutput && verboseMode) {
-                console.log(
-                  colors.dim +
-                    "  → Affected by changes in dependent package" +
-                    colors.reset,
-                );
+                console.log(colors.dim + `  → ${message}` + colors.reset);
               }
             }
           });

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ let jsonOutput = false;
 let verboseMode = false;
 let createTags = false;
 
-export function checkVersions(isCI: boolean = false): void {
+export async function checkVersions(isCI: boolean = false): Promise<void> {
   const args = process.argv.slice(2);
   jsonOutput = args.includes("--json");
   verboseMode = args.includes("--verbose");
@@ -292,7 +292,7 @@ export function checkVersions(isCI: boolean = false): void {
     }
   });
 
-  output(jsonOutput ? "json" : "cli", {
+  await output(jsonOutput ? "json" : "cli", {
     packageChanges,
     versionUpdates,
     cliOptions: {
@@ -315,7 +315,8 @@ export {
 
 // Main execution
 if (process.argv[1] === fileURLToPath(import.meta.url)) {
-  checkVersions(
-    process.env.CI === "true" || process.env.GITHUB_ACTIONS === "true",
-  );
+  checkVersions(process.env.CI === "true").catch((error) => {
+    console.error("Error:", error);
+    process.exit(1);
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,11 +33,13 @@ const packageChanges = new Map<Package, CommitInfo[]>();
 const versionUpdates = new Map<Package, VersionUpdate>();
 let jsonOutput = false;
 let verboseMode = false;
+let createTags = false;
 
 export function checkVersions(isCI: boolean = false): void {
   const args = process.argv.slice(2);
   jsonOutput = args.includes("--json");
   verboseMode = args.includes("--verbose");
+  createTags = args.includes("--publish");
 
   packageChanges.clear();
   versionUpdates.clear();
@@ -290,7 +292,16 @@ export function checkVersions(isCI: boolean = false): void {
     }
   });
 
-  output(jsonOutput ? "json" : "cli", packageChanges, versionUpdates);
+  output(jsonOutput ? "json" : "cli", {
+    packageChanges,
+    versionUpdates,
+    cliOptions: {
+      configPath: CONFIG_PATH,
+      jsonOutput,
+      verboseMode,
+      createTags,
+    },
+  });
 }
 
 // Export functions for testing

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,4 +1,4 @@
-import { formatCommit, runCommand } from "./commits.js";
+import { createTag, formatCommit } from "./commits.js";
 import { colors, printSection } from "./helpers.js";
 import { CLIOptions, CommitInfo, Package, VersionUpdate } from "./types.js";
 
@@ -146,8 +146,8 @@ function outputCLI(
     );
     for (const [pack, update] of versionUpdates) {
       const { tagPrefix, nextVersion } = update;
-      runCommand(`git tag ${tagPrefix}${nextVersion}`);
-      runCommand(`git push origin ${tagPrefix}${nextVersion}`);
+      const newTag = `${tagPrefix}${nextVersion}`;
+      createTag(newTag);
       console.log(
         `${colors.green}✓${colors.reset} ${pack.name}  ${colors.dim}${tagPrefix}${nextVersion}${colors.reset}`,
       );

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -78,17 +78,21 @@ function outputCLI(
   }
 
   console.log(
-    `\n${colors.bright}${colors.magenta}🚀 Release Check Summary${colors.reset}\n${separator}`
+    `\n${colors.bright}${colors.magenta}🚀 Release Check Summary${colors.reset}\n${separator}`,
   );
 
   // Changes Overview
   printSection("📦 Changes Detected:");
   if (packageChanges.size > 0) {
-    const maxPkgLength = Math.max(...[...packageChanges.keys()].map(pack => pack.name.length));
-    packageChanges.forEach((changes, pack) => {
+    const maxPkgLength = Math.max(
+      ...[...packageChanges.keys()].map((pack) => pack.name.length),
+    );
+    for (const [pack, changes] of packageChanges) {
       const pkg = pack.name.padEnd(maxPkgLength);
-      console.log(`${colors.green}✓${colors.reset} ${pkg}  ${colors.cyan}${changes.length}${colors.reset} commits`);
-    });
+      console.log(
+        `${colors.green}✓${colors.reset} ${pkg}  ${colors.cyan}${changes.length}${colors.reset} commits`,
+      );
+    }
   } else {
     console.log(`${colors.yellow}⚠ No changes detected${colors.reset}`);
   }
@@ -96,12 +100,16 @@ function outputCLI(
   // Version Updates
   printSection("📝 Version Updates:");
   if (versionUpdates.size > 0) {
-    const maxPkgLength = Math.max(...[...versionUpdates.keys()].map(pack => pack.name.length));
-    versionUpdates.forEach((update, pack) => {
+    const maxPkgLength = Math.max(
+      ...[...versionUpdates.keys()].map((pack) => pack.name.length),
+    );
+    for (const [pack, update] of versionUpdates) {
       const pkg = pack.name.padEnd(maxPkgLength);
       const { tagPrefix, currentVersion, nextVersion } = update;
-      console.log(`${colors.green}✓${colors.reset} ${pkg}  ${colors.dim}${tagPrefix}${currentVersion}${colors.reset} → ${colors.bright}${tagPrefix}${nextVersion}${colors.reset}`);
-    });
+      console.log(
+        `${colors.green}✓${colors.reset} ${pkg}  ${colors.dim}${tagPrefix}${currentVersion}${colors.reset} → ${colors.bright}${tagPrefix}${nextVersion}${colors.reset}`,
+      );
+    }
   } else {
     console.log(`${colors.yellow}⚠ No version updates needed${colors.reset}`);
   }
@@ -109,15 +117,21 @@ function outputCLI(
   // Detailed Changes
   printSection("🔍 Detailed Changes:");
   if (packageChanges.size > 0) {
-    packageChanges.forEach((changes, pack) => {
+    for (const [pack, changes] of packageChanges) {
       console.log(`\n${colors.cyan}${pack.name}${colors.reset}:`);
       changes.forEach(({ hash, message, reasons }) => {
-        console.log(`  ${colors.green}•${colors.reset} ${formatCommit(hash, message)}`);
-        reasons.forEach(reason => console.log(`    ${colors.dim}↳ ${reason}${colors.reset}`));
+        console.log(
+          `  ${colors.green}•${colors.reset} ${formatCommit(hash, message)}`,
+        );
+        reasons.forEach((reason) =>
+          console.log(`    ${colors.dim}↳ ${reason}${colors.reset}`),
+        );
       });
-    });
+    }
   } else {
-    console.log(`${colors.yellow}⚠ No detailed changes to show${colors.reset}`);
+    console.log(
+      `${colors.yellow}⚠ No detailed changes to show${colors.reset}`,
+    );
   }
 
   console.log(separator);

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,4 +1,4 @@
-import { formatCommit } from "./commits.js";
+import { formatCommit, runCommand } from "./commits.js";
 import { colors, printSection } from "./helpers.js";
 import { CLIOptions, CommitInfo, Package, VersionUpdate } from "./types.js";
 
@@ -139,4 +139,20 @@ function outputCLI(
   }
 
   console.log(separator);
+
+  if (cliOptions.createTags) {
+    console.log(
+      `\n${colors.bright}${colors.magenta}🚀 Creating and publishing tags${colors.reset}\n`,
+    );
+    for (const [pack, update] of versionUpdates) {
+      const { tagPrefix, nextVersion } = update;
+      runCommand(`git tag ${tagPrefix}${nextVersion}`);
+      runCommand(`git push origin ${tagPrefix}${nextVersion}`);
+      console.log(
+        `${colors.green}✓${colors.reset} ${pack.name}  ${colors.dim}${tagPrefix}${nextVersion}${colors.reset}`,
+      );
+    }
+
+    console.log(`\n${separator}`);
+  }
 }

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,0 +1,124 @@
+import { formatCommit } from "./commits.js";
+import { colors, printSection } from "./helpers.js";
+import { CommitInfo, Package, VersionUpdate } from "./types.js";
+
+/**
+ * Outputs the release summary to the console in a human-readable format or
+ * as JSON, depending on the mode.
+ *
+ * @param mode - The output mode. Either "json" or "cli".
+ * @param packageChanges - A map where each key is a Package object and each
+ * value is an array of CommitInfo objects containing commit information.
+ * @param versionUpdates - A map where each key is a Package object and each
+ * value is a VersionUpdate object containing version information.
+ */
+export function output(
+  mode: "json" | "cli",
+  packageChanges: Map<Package, CommitInfo[]>,
+  versionUpdates: Map<Package, VersionUpdate>,
+): void {
+  if (mode === "json") {
+    outputJSON(versionUpdates);
+  } else {
+    outputCLI(packageChanges, versionUpdates);
+  }
+}
+
+/**
+ * Converts a map of version updates to a JSON string and logs it.
+ *
+ * Each entry in the map contains the package name as the key and an object
+ * with current version, next version, and change status as the value.
+ *
+ * Use it in CI environment to output JSON to stdout.
+ * @param versionUpdates - A map where each key is a Package object and each
+ * value is a VersionUpdate object containing version information.
+ */
+function outputJSON(versionUpdates: Map<Package, VersionUpdate>): void {
+  const output: Map<
+    string,
+    {
+      currentVersion: string;
+      nextVersion: string;
+      hasChanges: boolean;
+    }
+  > = new Map();
+  for (const [pkg, version] of versionUpdates.entries()) {
+    output.set(pkg.name, {
+      currentVersion: version.currentVersion,
+      nextVersion: version.nextVersion,
+      hasChanges: version.hasChanges,
+    });
+  }
+  console.log(JSON.stringify(Object.fromEntries(output)));
+}
+
+/**
+ * Outputs the release summary to the console in a human-readable format.
+ *
+ * This function logs an overview of detected changes, version updates, and
+ * detailed changes for each package. It uses colored output for better
+ * readability and organizes the information into sections.
+ *
+ * @param packageChanges - A map where each key is a Package object and each
+ * value is an array of CommitInfo objects representing changes.
+ * @param versionUpdates - A map where each key is a Package object and each
+ * value is a VersionUpdate object containing version information.
+ */
+function outputCLI(
+  packageChanges: Map<Package, CommitInfo[]>,
+  versionUpdates: Map<Package, VersionUpdate>,
+): void {
+  const noUpdatesMessage = `${colors.green}${colors.bright} ✓ No version updates required!${colors.reset}`;
+  const separator = "\n" + colors.dim + "=".repeat(50) + colors.reset + "\n";
+
+  if (versionUpdates.size === 0) {
+    console.log(noUpdatesMessage);
+    return;
+  }
+
+  console.log(
+    `\n${colors.bright}${colors.magenta}🚀 Release Check Summary${colors.reset}\n${separator}`
+  );
+
+  // Changes Overview
+  printSection("📦 Changes Detected:");
+  if (packageChanges.size > 0) {
+    const maxPkgLength = Math.max(...[...packageChanges.keys()].map(pack => pack.name.length));
+    packageChanges.forEach((changes, pack) => {
+      const pkg = pack.name.padEnd(maxPkgLength);
+      console.log(`${colors.green}✓${colors.reset} ${pkg}  ${colors.cyan}${changes.length}${colors.reset} commits`);
+    });
+  } else {
+    console.log(`${colors.yellow}⚠ No changes detected${colors.reset}`);
+  }
+
+  // Version Updates
+  printSection("📝 Version Updates:");
+  if (versionUpdates.size > 0) {
+    const maxPkgLength = Math.max(...[...versionUpdates.keys()].map(pack => pack.name.length));
+    versionUpdates.forEach((update, pack) => {
+      const pkg = pack.name.padEnd(maxPkgLength);
+      const { tagPrefix, currentVersion, nextVersion } = update;
+      console.log(`${colors.green}✓${colors.reset} ${pkg}  ${colors.dim}${tagPrefix}${currentVersion}${colors.reset} → ${colors.bright}${tagPrefix}${nextVersion}${colors.reset}`);
+    });
+  } else {
+    console.log(`${colors.yellow}⚠ No version updates needed${colors.reset}`);
+  }
+
+  // Detailed Changes
+  printSection("🔍 Detailed Changes:");
+  if (packageChanges.size > 0) {
+    packageChanges.forEach((changes, pack) => {
+      console.log(`\n${colors.cyan}${pack.name}${colors.reset}:`);
+      changes.forEach(({ hash, message, reasons }) => {
+        console.log(`  ${colors.green}•${colors.reset} ${formatCommit(hash, message)}`);
+        reasons.forEach(reason => console.log(`    ${colors.dim}↳ ${reason}${colors.reset}`));
+      });
+    });
+  } else {
+    console.log(`${colors.yellow}⚠ No detailed changes to show${colors.reset}`);
+  }
+
+  console.log(separator);
+}

--- a/src/outputs.ts
+++ b/src/outputs.ts
@@ -1,6 +1,6 @@
 import { formatCommit } from "./commits.js";
 import { colors, printSection } from "./helpers.js";
-import { CommitInfo, Package, VersionUpdate } from "./types.js";
+import { CLIOptions, CommitInfo, Package, VersionUpdate } from "./types.js";
 
 /**
  * Outputs the release summary to the console in a human-readable format or
@@ -14,13 +14,16 @@ import { CommitInfo, Package, VersionUpdate } from "./types.js";
  */
 export function output(
   mode: "json" | "cli",
-  packageChanges: Map<Package, CommitInfo[]>,
-  versionUpdates: Map<Package, VersionUpdate>,
+  data: {
+    packageChanges: Map<Package, CommitInfo[]>;
+    versionUpdates: Map<Package, VersionUpdate>;
+    cliOptions: CLIOptions;
+  },
 ): void {
   if (mode === "json") {
-    outputJSON(versionUpdates);
+    outputJSON(data.versionUpdates);
   } else {
-    outputCLI(packageChanges, versionUpdates);
+    outputCLI(data.cliOptions, data.packageChanges, data.versionUpdates);
   }
 }
 
@@ -66,6 +69,7 @@ function outputJSON(versionUpdates: Map<Package, VersionUpdate>): void {
  * value is a VersionUpdate object containing version information.
  */
 function outputCLI(
+  cliOptions: CLIOptions,
   packageChanges: Map<Package, CommitInfo[]>,
   versionUpdates: Map<Package, VersionUpdate>,
 ): void {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,13 @@ export interface Package {
   dependsOn: string[];
 }
 
+export interface CLIOptions {
+  configPath: string;
+  jsonOutput: boolean;
+  verboseMode?: boolean;
+  createTags?: boolean;
+}
+
 export interface VersionChanges {
   major: boolean;
   minor: boolean;


### PR DESCRIPTION
This PR introduces automated tag creation and publishing capabilities to streamline the versioning workflow. It adds two key features:

1. **Automated Tag Creation (`--publish` flag)**
   - New `--publish` flag for automatic tag creation and publishing
   - Perfect for CI environments or automated workflows
   - Creates and pushes tags in a single step when new versions are detected

2. **Interactive Tag Management**
   - When `--publish` is not used, provides an interactive prompt for flexible tag handling
   - Quick single-keystroke options:
     - `Y` (default): Create and publish tags
     - `N`: Skip tag creation
     - `C`: Create tags locally without pushing
   - Immediate feedback with no need to press Enter
   - Clear visual feedback about actions taken

This enhancement makes the versioning workflow more flexible and user-friendly, allowing users to:
- Review changes before pushing tags in interactive mode
- Create tags locally for testing before pushing to remote

Example usage:
```bash
# Automated mode
npx get-next-versions --publish

# Interactive mode
npx get-next-versions  # Will prompt for tag creation options
```

> Note: neither interactive mode nor the `--publish` flag work when `--json` is provided or when in CI!


Closes #3 